### PR TITLE
munki recipie

### DIFF
--- a/monitoringclient/MonitoringClient.munki.recipe
+++ b/monitoringclient/MonitoringClient.munki.recipe
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest Monitoring Client installation package and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.munki.monitoringclient</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MonitoringClient</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>MonitoringClient</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>This munki processor needs to point to your override file's output.</string>
+            <key>display_name</key>
+            <string>Monitoring Client</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.watchmanmonitoring.download.monitoringclient</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Requires an override of `SUBDOMAIN` which will be made available via

https://app.monitoringclient.com/installers/mac#autopkg

Closes #5
