### PR TITLE
Adds version number to the downloads, cleans up output

### DIFF
--- a/monitoringclient/MonitoringClient.download.recipe
+++ b/monitoringclient/MonitoringClient.download.recipe
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%SUBDOMAIN%.pkg</string>
+                <string>%NAME%-%version%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/monitoringclient/MonitoringClient.download.recipe
+++ b/monitoringclient/MonitoringClient.download.recipe
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%-%SUBDOMAIN%-%version%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/monitoringclient/MonitoringClientExtensionAttribute.xml
+++ b/monitoringclient/MonitoringClientExtensionAttribute.xml
@@ -6,7 +6,7 @@
 		<type>script</type>
 		<platform>Mac</platform>
 		<script>#!/bin/bash
-MonitoringClientVersion=""
+MonitoringClientVersion="Not Installed"
 if [[ -f /Library/MonitoringClient/ClientSettings.plist ]]
 	then
 		MonitoringClientVersion=$(defaults read /Library/MonitoringClient/ClientSettings.plist Client_Version)

--- a/monitoringclient/MonitoringClientSmartGroupTemplate.xml
+++ b/monitoringclient/MonitoringClientSmartGroupTemplate.xml
@@ -14,7 +14,7 @@
 			<priority>1</priority>
 			<and_or>and</and_or>
 			<search_type>is not</search_type>
-			<value></value>
+			<value>Not Installed</value>
 		</criterion>
 		<criterion>
 			<name>Computer Group</name>


### PR DESCRIPTION
We can add the subdomain back into the pkg name if you'd like, but if there's no version information, JSSImporter will see that the pkg already exists on the distribution points and won't reupload. The other two changes are going from a blank space as the default on the EA to "Not Installed" which looks a little bit nicer and is a little more obvious at a quick glance.