### PR TITLE
Deprecate JSS recipes

### DIFF
--- a/monitoringclient/MonitoringClient.jss.recipe
+++ b/monitoringclient/MonitoringClient.jss.recipe
@@ -1,75 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
- 	<key>Description</key>
- 	<string>Downloads latest version of the MonitoringClient.pkg, and uploads it to the JSS. An override file is required to set the subdomain.</string>
- 	<key>Identifier</key>
- 	<string>com.github.watchmanmonitoring.jss.monitoringclient</string>
- 	<key>Input</key>
- 	<dict>
- 		<key>CATEGORY</key>
- 		<string>Utilities</string>
- 		<key>GROUP_NAME</key>
- 		<string>%NAME%-update-smart</string>
- 		<key>GROUP_TEMPLATE</key>
- 		<string>MonitoringClientSmartGroupTemplate.xml</string>
- 		<key>NAME</key>
- 		<string>MonitoringClient</string>
- 		<key>POLICY_CATEGORY</key>
- 		<string>Testing</string>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads latest version of the MonitoringClient.pkg, and uploads it to the JSS. An override file is required to set the subdomain.</string>
+	<key>Identifier</key>
+	<string>com.github.watchmanmonitoring.jss.monitoringclient</string>
+	<key>Input</key>
+	<dict>
+		<key>CATEGORY</key>
+		<string>Utilities</string>
+		<key>GROUP_NAME</key>
+		<string>%NAME%-update-smart</string>
+		<key>GROUP_TEMPLATE</key>
+		<string>MonitoringClientSmartGroupTemplate.xml</string>
+		<key>NAME</key>
+		<string>MonitoringClient</string>
+		<key>POLICY_CATEGORY</key>
+		<string>Testing</string>
+		<key>POLICY_TEMPLATE</key>
+		<string>PolicyTemplate.xml</string>
+		<key>SELF_SERVICE_DESCRIPTION</key>
+		<string>A tool which detects issues on your Mac, and reports them to IT.</string>
+		<key>SELF_SERVICE_ICON</key>
+		<string>MonitoringClient.png</string>
 		<key>SUBDOMAIN</key>
 		<string>www</string>
- 		<key>POLICY_TEMPLATE</key>
- 		<string>PolicyTemplate.xml</string>
- 		<key>SELF_SERVICE_DESCRIPTION</key>
- 		<string>A tool which detects issues on your Mac, and reports them to IT.</string>
- 		<key>SELF_SERVICE_ICON</key>
- 		<string>MonitoringClient.png</string>
- 	</dict>
- 	<key>MinimumVersion</key>
- 	<string>0.2.0</string>
- 	<key>ParentRecipe</key>
- 	<string>com.github.watchmanmonitoring.download.monitoringclient</string>
- 	<key>Process</key>
- 	<array>
- 		<dict>
- 			<key>Arguments</key>
- 			<dict>
- 				<key>category</key>
- 				<string>%CATEGORY%</string>
-        <key>extension_attributes</key>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.watchmanmonitoring.download.monitoringclient</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>category</key>
+				<string>%CATEGORY%</string>
+				<key>extension_attributes</key>
 				<array>
 					<dict>
 						<key>ext_attribute_path</key>
 						<string>MonitoringClientExtensionAttribute.xml</string>
 					</dict>
 				</array>
- 				<key>groups</key>
- 				<array>
- 					<dict>
- 						<key>name</key>
- 						<string>%GROUP_NAME%</string>
- 						<key>smart</key>
- 						<true/>
- 						<key>template_path</key>
- 						<string>%GROUP_TEMPLATE%</string>
- 					</dict>
- 				</array>
- 				<key>policy_category</key>
- 				<string>%POLICY_CATEGORY%</string>
- 				<key>policy_template</key>
- 				<string>%POLICY_TEMPLATE%</string>
- 				<key>prod_name</key>
- 				<string>%NAME%</string>
- 				<key>self_service_description</key>
- 				<string>%SELF_SERVICE_DESCRIPTION%</string>
- 				<key>self_service_icon</key>
- 				<string>%SELF_SERVICE_ICON%</string>
- 			</dict>
- 			<key>Processor</key>
- 			<string>JSSImporter</string>
- 		</dict>
- 	</array>
- </dict>
- </plist>
+				<key>groups</key>
+				<array>
+					<dict>
+						<key>name</key>
+						<string>%GROUP_NAME%</string>
+						<key>smart</key>
+						<true/>
+						<key>template_path</key>
+						<string>%GROUP_TEMPLATE%</string>
+					</dict>
+				</array>
+				<key>policy_category</key>
+				<string>%POLICY_CATEGORY%</string>
+				<key>policy_template</key>
+				<string>%POLICY_TEMPLATE%</string>
+				<key>prod_name</key>
+				<string>%NAME%</string>
+				<key>self_service_description</key>
+				<string>%SELF_SERVICE_DESCRIPTION%</string>
+				<key>self_service_icon</key>
+				<string>%SELF_SERVICE_ICON%</string>
+			</dict>
+			<key>Processor</key>
+			<string>JSSImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
[JSSImporter](https://github.com/jssimporter/JSSImporter) is no longer maintained. This pull request marks JSS type recipes as deprecated, and urges users to consider switching to equivalent [JamfUploader](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors) recipes.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._